### PR TITLE
Fail the pages job on Sphinx warnings

### DIFF
--- a/doc/.gitlab-ci.yml
+++ b/doc/.gitlab-ci.yml
@@ -4,8 +4,15 @@ pages:
   tags:
     - sphinx
   stage: deploy
+  # -W turns warnings into errors. Without it, an extension that cannot
+  # reach its native tool — plantuml without a JRE, imgmath without LaTeX —
+  # only logs a warning and drops the node: the job stays green while the
+  # diagrams and the formulas are missing from the published pages.
+  # --keep-going reports every warning of the run instead of stopping at
+  # the first one.
+
   script:
-    - sphinx-build -b html doc/source/ public/
+    - sphinx-build -W --keep-going -b html doc/source/ public/
   artifacts:
     paths:
       - public


### PR DESCRIPTION
The `pages` job of this repository builds with `sphinx-build -b html`, without `-W`.

`sphinxcontrib-plantuml` and `sphinx.ext.imgmath`, both enabled by `doc/source/conf.py`, do not fail when their native tool is missing: they log a warning, drop the node, and let the job finish green. The published pages then have holes where the diagrams and the formulas should be, and nothing signals it.

The image was fixed on 2026-08-20 by installing a JRE and LaTeX in it, and both the GitLab infrabase and edgem1 build with `-W --keep-going` since. This repository kept the unguarded job, so the two copies of the file had drifted apart.

### What changes

```diff
-    - sphinx-build -b html doc/source/ public/
+    - sphinx-build -W --keep-going -b html doc/source/ public/
```

plus the comment explaining why, and a trailing newline the file was missing. The file is now byte for byte identical to the one in the GitLab infrabase, so a later diff between them shows only what really differs.

### Verification

This documentation tree builds under `-W --keep-going` and exits 0, so the guard does not turn the job red on the current content.